### PR TITLE
Change for GetCurrentMission

### DIFF
--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -99,6 +99,7 @@ t.onWindowShown = Event()
 t.onWindowHidden = Event()
 
 t.onMissionChanged = Event()
+t.onMissionDismissed = Event()
 t.onGameVictory = Event()
 
 t.onShiftToggled = Event()

--- a/scripts/mod_loader/modapi/mission.lua
+++ b/scripts/mod_loader/modapi/mission.lua
@@ -25,6 +25,12 @@ modApi.events.onMissionChanged:subscribe(function(currentMission, oldCurrentMiss
 	)
 end)
 
+modApi.events.onMissionDismissed:subscribe(function(mission)
+	local id = mission and mission.ID or nil
+
+	LOGF("-> Current mission %s w/table [%s] was dismissed", tostring(id), tostring(mission))
+end)
+
 -- Test if GetCurrentMission() is equal to 'self' in every Mission method.
 for i, fn in pairs(Mission) do
 	if type(fn) == 'function' then
@@ -75,6 +81,10 @@ modApi.events.onMissionUpdate:subscribe(function(mission)
 	if currentMission ~= mission then
 		modApi:setMission(mission)
 	end
+end)
+
+modApi.events.onMissionDismissed:subscribe(function(mission)
+	modApi:setMission(nil)
 end)
 
 modApi.events.onGameExited:subscribe(function()

--- a/scripts/mod_loader/modapi/mission.lua
+++ b/scripts/mod_loader/modapi/mission.lua
@@ -9,47 +9,6 @@ modApi.events.onFrameDrawStart:subscribe(function()
 end)
 
 
--- TESTS
---------
-
--- Logout when mission changes.
-modApi.events.onMissionChanged:subscribe(function(currentMission, oldCurrentMission)
-	local oldId = oldCurrentMission and oldCurrentMission.ID or nil
-	local newId = currentMission and currentMission.ID or nil
-
-	LOGF("-> Current mission changed from %s w/table [%s] to %s w/table [%s]",
-		tostring(oldId),
-		tostring(oldCurrentMission),
-		tostring(newId),
-		tostring(currentMission)
-	)
-end)
-
-modApi.events.onMissionDismissed:subscribe(function(mission)
-	local id = mission and mission.ID or nil
-
-	LOGF("-> Current mission %s w/table [%s] was dismissed", tostring(id), tostring(mission))
-end)
-
--- Test if GetCurrentMission() is equal to 'self' in every Mission method.
-for i, fn in pairs(Mission) do
-	if type(fn) == 'function' then
-		local oldfn = fn
-		fn = function(mission, ...)
-			if GetCurrentMission() ~= mission then
-				LOGF("-> Mission:%s: GetCurrentMission() (%s) differs from 'self' (%s)",
-					tostring(i),
-					tostring(GetCurrentMission()),
-					tostring(mission)
-				)
-			end
-
-			return oldfn(mission, ...)
-		end
-	end
-end
-
-
 -- GetCurrentMission
 --------------------
 

--- a/scripts/mod_loader/modapi/mission.lua
+++ b/scripts/mod_loader/modapi/mission.lua
@@ -1,4 +1,42 @@
 
+-- TESTS
+--------
+
+-- Logout when mission changes.
+modApi.events.onMissionChanged:subscribe(function(currentMission, oldCurrentMission)
+	local oldId = oldCurrentMission and oldCurrentMission.ID or nil
+	local newId = currentMission and currentMission.ID or nil
+
+	LOGF("-> Current mission changed from %s w/table [%s] to %s w/table [%s]",
+		tostring(oldId),
+		tostring(oldCurrentMission),
+		tostring(newId),
+		tostring(currentMission)
+	)
+end)
+
+-- Test if GetCurrentMission() is equal to 'self' in every Mission method.
+for i, fn in pairs(Mission) do
+	if type(fn) == 'function' then
+		local oldfn = fn
+		fn = function(mission, ...)
+			if GetCurrentMission() ~= mission then
+				LOGF("-> Mission:%s: GetCurrentMission() (%s) differs from 'self' (%s)",
+					tostring(i),
+					tostring(GetCurrentMission()),
+					tostring(mission)
+				)
+			end
+
+			return oldfn(mission, ...)
+		end
+	end
+end
+
+
+-- GetCurrentMission
+--------------------
+
 function modApi:setMission(mission)
 	local oldMission = self.current_mission
 
@@ -9,38 +47,22 @@ function modApi:setMission(mission)
 	end
 end
 
-local currentRegionData
-modApi.events.onSaveDataUpdated:subscribe(function()
-	if currentRegionData ~= RegionData then
-		currentRegionData = RegionData
-
-		local region = GetCurrentRegion(RegionData)
-		local mission = nil
-
-		if region then
-			mission = GAME:GetMission(region.mission)
-		end
-
-		if not region and modApi.current_mission and not modApi.current_mission.Deployed then
-			-- When updating the save file in MissionStart event listener (ie, from
-			-- Mission:BaseDeployment context), RegionData doesn't have `iBattleRegion` entry yet,
-			-- so we have no way of finding the current region/mission, and end up setting current
-			-- mission to nil.
-			-- To fix this, keep track of missions that are past the deployment phase with `Deployed`
-			-- flag, and check if the mission we have saved currently is already past that phase.
-			-- This way we know that we've been called from within BaseDeployment context, and don't
-			-- execute this block eg. when leaving a mission, which would be incorrect behaviour.
-			mission = modApi.current_mission
-		end
-
-		if not IsTestMechScenario() then
-			modApi:setMission(mission)
-		end
-	end
+modApi.events.onMissionStart:subscribe(function(mission)
+	modApi:setMission(mission)
 end)
 
 modApi.events.onMissionNextPhaseCreated:subscribe(function(prevMission, nextMission)
 	modApi:setMission(nextMission)
+end)
+
+modApi.events.onMissionEnd:subscribe(function(mission)
+	modApi:setMission(nil)
+end)
+
+modApi.events.onMissionUpdate:subscribe(function(mission)
+	if currentMission ~= mission then
+		modApi:setMission(mission)
+	end
 end)
 
 modApi.events.onGameExited:subscribe(function()

--- a/scripts/mod_loader/modapi/mission.lua
+++ b/scripts/mod_loader/modapi/mission.lua
@@ -1,4 +1,14 @@
 
+-- EVENTS
+---------
+
+modApi.events.onFrameDrawStart:subscribe(function()
+	if modApi.current_mission ~= nil and Board == nil then
+		modApi.events.onMissionDismissed:dispatch(modApi.current_mission)
+	end
+end)
+
+
 -- TESTS
 --------
 
@@ -56,7 +66,9 @@ modApi.events.onMissionNextPhaseCreated:subscribe(function(prevMission, nextMiss
 end)
 
 modApi.events.onMissionEnd:subscribe(function(mission)
-	modApi:setMission(nil)
+	-- When entering a saved game from the main menu,
+	-- this is the first function being called for the current mission
+	modApi:setMission(mission)
 end)
 
 modApi.events.onMissionUpdate:subscribe(function(mission)


### PR DESCRIPTION
Pre ITB-AE, `GetCurrentMission` used savedata to stay updated on which mission is the current mission. Post ITB-AE, something in the save data appears to have changed, and the function no longer functions as intended. See #130 

This PR changes `GetCurrentMission` to use a different method of keeping the current mission up to date, that does not rely on polling save data.

# Add
- event `onMissionDismissed` - is dispatched when the end screen of a mission is dismissed

# Changes
- internal logic for `GetCurrentMission` changed to rely on mission's own functions to stay up to date.
- `onMissionDismissed` is used to clear the `current mission`.

# ~~Temporary Tests~~
 - ~~Each method of `Mission` overridden to log out when `GetCurrentMission` differs from the first parameter sent to the method. If any such log in the console is detected, something has gone wrong.~~
- ~~Log out `current mission` and previously held `current mission` when event `onMissionChanged` is dispatched.~~