### PR TITLE
Improve efficiency of modifying resource.dat file

### DIFF
--- a/scripts/mod_loader/ftldat/ftldat.lua
+++ b/scripts/mod_loader/ftldat/ftldat.lua
@@ -20,7 +20,7 @@ function FtlDat:_init(p__io, p__parent, p__root)
 	self.m_root = p__root or self
 	self.signature = false
 	-- initialize some fields to make sure they are never nil
-	self.remove_all_files()
+	self:remove_all_files()
 end
 
 function FtlDat:remove_all_files()

--- a/scripts/mod_loader/ftldat/ftldat.lua
+++ b/scripts/mod_loader/ftldat/ftldat.lua
@@ -87,6 +87,8 @@ function Meta:_read(signature_scan)
 	self._fileSize = self._io:read_u4le()
 	self._filenameSize = self._io:read_u4le()
 	self._filename = self._io:read_bytes(self._filenameSize)
+	-- signature scan means we only want filenames to see if the signature is set
+	-- the position will be reset after reading this meta, so as long as we read everything before the filename, we do not have the read the body
 	if not signature_scan then
 		self.body = self._io:read_bytes(self._fileSize)
 	end

--- a/scripts/mod_loader/ftldat/ftldat.lua
+++ b/scripts/mod_loader/ftldat/ftldat.lua
@@ -19,6 +19,14 @@ function FtlDat:_init(p__io, p__parent, p__root)
 	self.m_parent = p__parent
 	self.m_root = p__root or self
 	self.signature = false
+	-- initialize some fields to make sure they are never nil
+	self.remove_all_files()
+end
+
+function FtlDat:remove_all_files()
+	self._files = {}
+	self._filesByName = {}
+	self._numFiles = 0
 end
 
 function FtlDat:_read(signature_scan)
@@ -106,12 +114,6 @@ end
 
 
 -- ITB mod loader added helpers
-
-function FtlDat:remove_all_files()
-	self._files = {}
-	self._filesByName = {}
-	self._numFiles = 0
-end
 
 -- internal - inserts without increasing file count
 function FtlDat:_insert_file(file)

--- a/scripts/mod_loader/ftldat/ftldat.lua
+++ b/scripts/mod_loader/ftldat/ftldat.lua
@@ -25,7 +25,7 @@ function FtlDat:_read()
 	self._numFiles = self._io:read_u4le()
 
 	self._files = {}
-	self._fileIndexes = {}
+	self._filesByName = {}
 	for i = 1, self._numFiles do
 		local file = File(self._io, self, self.m_root)
 		file:_read()
@@ -105,15 +105,14 @@ end
 
 function FtlDat:remove_all_files()
 	self._files = {}
-	self._fileIndexes = {}
+	self._filesByName = {}
 	self._numFiles = 0
 end
 
 -- internal - inserts without increasing file count
 function FtlDat:_insert_file(file)
-	local index = #self._files + 1
 	table.insert(self._files, file)
-	self._fileIndexes[file._meta._filename] = index
+	self._filesByName[file._meta._filename] = file
 end
 
 -- helper to add a file and store its index in the by name lookup
@@ -125,22 +124,12 @@ end
 
 -- Helper to check if a file exists
 function FtlDat:file_exists(name)
-	return self._fileIndexes[name] ~= nil
+	return self._filesByName[name] ~= nil
 end
 
 -- helper to look up a file by name
 function FtlDat:find_existing_file(name)
-	-- must exist in our index lookup
-	local index = self._fileIndexes[name]
-	if index ~= nil then
-		-- must have a file at that index
-		local file = self._files[index]
-		if file ~= nil then
-			-- sanity check, that file should have a matching name
-			assert(name == file._meta._filename)
-			return file
-		end
-	end
+	return self._filesByName[name]
 end
 
 return {

--- a/scripts/mod_loader/ftldat/kaitai_struct_lua_runtime/kaitaistruct.lua
+++ b/scripts/mod_loader/ftldat/kaitai_struct_lua_runtime/kaitaistruct.lua
@@ -11,10 +11,10 @@ function KaitaiStruct:close()
     self._io:close()
 end
 
-function KaitaiStruct:from_file(filename)
+function KaitaiStruct:from_file(filename, cloneStream)
     local inp = assert(io.open(filename, "rb"))
 
-    local instance = self(KaitaiStream(inp))
+    local instance = self(KaitaiStream(inp, cloneStream))
     instance:_read()
 	return instance
 end
@@ -22,17 +22,21 @@ end
 function KaitaiStruct:from_string(s)
     local ss = stringstream(s)
 
-    local instance = self(KaitaiStream(ss))
+    local instance = self(KaitaiStream(ss, false))
     instance:_read()
 	return instance
 end
 
 KaitaiStream = class.class()
 
-function KaitaiStream:_init(io)
-	local s = io:read("*all")
-	io:close()
-    self._io = stringstream(s)
+function KaitaiStream:_init(io, cloneStream)
+    if cloneStream == true then
+	     local s = io:read("*all")
+       self._io = stringstream(s)
+       io:close()
+    else
+      self._io = io
+    end
     self:align_to_byte()
 end
 

--- a/scripts/mod_loader/modapi/ftldat.lua
+++ b/scripts/mod_loader/modapi/ftldat.lua
@@ -7,7 +7,7 @@ function modApi:assetExists(resource)
 	Assert.ResourceDatIsOpen("assetExists")
 	Assert.Equals("string", type(resource))
 
-	return self.resource.file_exists(resource)
+	return self.resource:file_exists(resource)
 end
 
 --[[

--- a/scripts/mod_loader/modapi/ftldat.lua
+++ b/scripts/mod_loader/modapi/ftldat.lua
@@ -6,14 +6,8 @@ local FtlDat = require("scripts/mod_loader/ftldat/ftldat")
 function modApi:assetExists(resource)
 	Assert.ResourceDatIsOpen("assetExists")
 	Assert.Equals("string", type(resource))
-	
-	for i, file in ipairs(self.resource._files) do
-		if file._meta._filename == resource then
-			return true
-		end
-	end
-	
-	return false
+
+	return self.resource.file_exists(resource)
 end
 
 --[[
@@ -29,28 +23,24 @@ function modApi:writeAsset(resource, content)
 	Assert.Equals("string", type(resource))
 	Assert.Equals("string", type(content))
 
-	for i, file in ipairs(self.resource._files) do
-		if file._meta._filename == resource then
-			file._meta.body = content
-			file._meta._fileSize = file._meta.body:len()
-
-			-- Overwriting an existing file, return early
-			return
-		end
+	local existing = self.resource:find_existing_file(resource)
+	if existing ~= nil then
+		existing._meta.body = content
+		existing._meta._fileSize = content:len()
+		-- Overwriting an existing file, return early
+		return
 	end
 
 	-- Writing a new file to the archive
-	self.resource._numFiles = self.resource._numFiles + 1
-
 	local file = FtlDat.File(self.resource._io,self.resource,self.resource.m_root)
 	file._meta = FtlDat.Meta(file._io, file, file.m_root)
-	
+
 	file._meta._filenameSize = resource:len()
 	file._meta._filename = resource
 	file._meta.body = content
 	file._meta._fileSize = file._meta.body:len()
 
-	table.insert(self.resource._files, file)
+	self.resource:insert_file(file)
 end
 
 --[[
@@ -66,10 +56,9 @@ function modApi:readAsset(resource)
 	Assert.ResourceDatIsOpen("readAsset")
 	Assert.Equals("string", type(resource))
 
-	for i, file in ipairs(self.resource._files) do
-		if file._meta._filename == resource then
-			return file._meta.body
-		end
+	local existing = self.resource:find_existing_file(resource)
+	if existing ~= nil then
+		return existing._meta.body
 	end
 
 	error(string.format("Could not find file '%s' in resource.dat archive", resource))
@@ -100,22 +89,14 @@ end
 
 function modApi:appendDat(filePath)
 	local instance = FtlDat.FtlDat:from_file(filePath)
-	
+
 	for i, file in ipairs(instance._files) do
-		local found = false
-		for j, og in ipairs(self.resource) do
-			if file._meta._filename == og._meta._filename then
-				og._meta.body = file._meta.body
-				og._meta._fileSize = file._meta._fileSize
-				found = true
-			
-				break
-			end
-		end
-		
-		if not found then
-			table.insert(self.resource._files,file)
-			self.resource._numFiles = self.resource._numFiles + 1
+		local existing = self.resource:find_existing_file(file._meta._filename)
+		if existing ~= nil then
+			existing._meta.body = file._meta.body
+			existing._meta._fileSize = file._meta._fileSize
+		else
+			self.resource:insert_file(file)
 		end
 	end
 end
@@ -130,9 +111,8 @@ function modApi:fileDirectoryToDat(path)
 	end
 	
 	local ftldat = FtlDat.FtlDat()
-	ftldat._files = {}
-	ftldat._numFiles = 0
-	
+	ftldat:remove_all_files()
+
 	local function addDir(directory)
 		for i, dir in pairs(os.listdirs(path..directory)) do
 			addDir(directory..dir.."/")
@@ -140,9 +120,7 @@ function modApi:fileDirectoryToDat(path)
 		for i, dirfile in pairs(os.listfiles(path..directory)) do
 			
 			local f = io.open(path..directory..dirfile,"rb")
-			
-			ftldat._numFiles = ftldat._numFiles + 1
-	
+
 			local file = FtlDat.File()
 			file._meta = FtlDat.Meta()
 	
@@ -152,8 +130,8 @@ function modApi:fileDirectoryToDat(path)
 			file._meta._fileSize = file._meta.body:len()
 			
 			f:close()
-			
-			table.insert(ftldat._files,file)
+
+			ftldat:insert_file(file)
 		end
 	end
 	
@@ -176,7 +154,6 @@ function modApi:finalize()
 
 		if not self.resource.signature then
 			self.resource.signature = true
-			self.resource._numFiles = self.resource._numFiles + 1
 			local file = FtlDat.File(self.resource._io,self.resource,self.resource.m_root)
 			file._meta = FtlDat.Meta(file._io, file, file.m_root)
 
@@ -184,7 +161,7 @@ function modApi:finalize()
 			file._meta._filenameSize = file._meta._filename:len()
 			file._meta.body = "OK"
 			file._meta._fileSize = file._meta.body:len()
-			table.insert(self.resource._files,file)
+			self.resource:insert_file(file)
 		end
 
 		local output = self.resource:_write()

--- a/scripts/mod_loader/modapi/init.lua
+++ b/scripts/mod_loader/modapi/init.lua
@@ -56,7 +56,7 @@ function modApi:init()
 				LOGD("Building FTLDat...")
 				Assert.NotEquals(0, stream:size(), "Size of content of resource.dat")
 				instance = FtlDat.FtlDat(stream)
-				instance:_read() -- TODO: we could simply do a signature scan instead of a full read
+				instance:_read(true)
 				instance._io:close()
 				LOGD("Done!")
 			end)

--- a/scripts/mod_loader/modapi/init.lua
+++ b/scripts/mod_loader/modapi/init.lua
@@ -56,6 +56,7 @@ function modApi:init()
 				LOGD("Building FTLDat...")
 				Assert.NotEquals(0, stream:size(), "Size of content of resource.dat")
 				instance = FtlDat.FtlDat(stream)
+				instance:_read() -- TODO: we could simply do a signature scan instead of a full read
 				instance._io:close()
 				LOGD("Done!")
 			end)

--- a/scripts/mod_loader/modapi/init.lua
+++ b/scripts/mod_loader/modapi/init.lua
@@ -50,13 +50,13 @@ function modApi:init()
 
 			local instance = nil
 			try(function()
-				local content = file:read("*all")
-				file:close()
+				-- use stream instead of io:read("*all") as it *drastically* reduces memory
+				local stream = KaitaiStream(file)
 
 				LOGD("Building FTLDat...")
-				Assert.NotEquals(nil, content, "Reading resource.dat")
-				Assert.NotEquals(0, string.len(content), "Size of content of resource.dat")
-				instance = FtlDat.FtlDat:from_string(content)
+				Assert.NotEquals(0, stream:size(), "Size of content of resource.dat")
+				instance = FtlDat.FtlDat(stream)
+				instance._io:close()
 				LOGD("Done!")
 			end)
 			:catch(function(err)
@@ -77,6 +77,8 @@ function modApi:init()
 
 	LOGD("Building FTLDat...")
 	self.resource = FtlDat.FtlDat:from_file("resources/resource.dat")
+	-- self.resource already read in all data, so we can safely close the stream
+	self.resource._io:close()
 	LOGD("Done!")
 
 	self.squadKeys = {


### PR DESCRIPTION
Did a loose benchmark:

* Old startup time:
    * With no resource.dat.bak: around 50 seconds
    * With resource.dat.bak: around 65 seconds
* After changes
    * With no resource.dat.bak: around 27 seconds
    * With resource.dat.bak: around 30 seconds

Breakdown of improvement by change:
* Switching from list search to hash search: 3-4 seconds
* Removing stream copying: 14 seconds with no resource.dat.bak, around 30 seconds with it
* Faster signature scan: around 3 seconds

Note: startup times include the loading bar, which takes about 7 seconds. Meaning all the modloader preloading stuff takes around 40-55 seconds before changes, and around 20-23 seconds after.

----

Note: we could possibly save a few more seconds if we inject our signature into the start of `resource.dat` and break the signature scan loop as soon as its found. Based on how fast it ran with the broken signature scan code I had earlier, I doubt it would be much more than a second gain, so probably not worth it (plus, not sure if there is risk with changing the order of files)

----

Testing:
* If you contribute to the modloader, you know how to test
* If not, test by installing the mod loader using this link: [ITB-ModLoader-2.7.0-faster-resource-dat.zip](https://github.com/itb-community/ITB-ModLoader/files/9174852/ITB-ModLoader-2.7.0-faster-resource-dat.zip)