### PR TITLE
Add `onModEnumerating` event

### DIFF
--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -16,6 +16,7 @@ modApi.events = {}
 setmetatable(modApi.events, events_mt)
 
 local t = modApi.events
+t.onModEnumerating = Event()
 t.onModMetadataDone = Event()
 t.onModsMetadataDone = Event()
 t.onModInitialized = Event()

--- a/scripts/mod_loader/mod_loader.lua
+++ b/scripts/mod_loader/mod_loader.lua
@@ -57,6 +57,7 @@ function mod_loader:init()
 
 	LOGD("Enumerating mods...")
 	self:enumerateMods("mods/")
+	modApi.events.onModEnumerating:unsubscribeAll()
 	LOGD("Done!")
 
 	if MOD_API_DRAW_HOOK then
@@ -197,6 +198,8 @@ function mod_loader:enumerateMods(dirPathRelativeToGameDir, parentMod)
 				initFilePath = modDirPath .. "scripts/init.lua"
 			end
 		end
+
+        modApi.events.onModEnumerating:dispatch(modDirPath)
 
 		local function fn()
 			return dofile(initFilePath)


### PR DESCRIPTION
This PR adds a new event `modApi.events.onModEnumerating`, which takes the path to a mod's directory as argument, and runs before the mod's init.lua file is executed. This allows the mod loader to alter mod files before they're loaded to apply fixes, or inspect mod content.