### PR TITLE
Sort squad units when adding squad

### DIFF
--- a/scripts/mod_loader/modapi/squad.lua
+++ b/scripts/mod_loader/modapi/squad.lua
@@ -37,6 +37,9 @@ function modApi:addSquad(squad, name, desc, icon)
 	squad.id = squad.id or buildSquadId(squad)
 	Assert.Equals(nil, modApi.mod_squads_by_id[squad.id], string.format("Squad with id %q already exists", squad.id))
 
+	-- sort the squad name first
+	local mechOrder = {[squad[1]] = -1}
+
 	-- Validate the squad
 	for i = 2, 4 do
 		local mechType = squad[i]
@@ -52,17 +55,11 @@ function modApi:addSquad(squad, name, desc, icon)
 				string.format("Squad %q - pawn with id %q has an invalid Class", squad.id, mechType)
 		)
 
-		if i > 2 then
-			local ptable_prev = _G[squad[i-1]]
-			local pri = CLASS_ORDER[ptable.Class] or INT_MAX
-			local pri_prev = CLASS_ORDER[ptable_prev.Class] or INT_MAX
-
-			if pri < pri_prev then
-				-- swap entries
-				squad[i-1], squad[i] = squad[i], squad[i-1]
-			end
-		end
+		mechOrder[mechType] = CLASS_ORDER[ptable.Class] or INT_MAX
 	end
+
+	-- sort mechs in squad by class
+	table.sort(squad, function(a, b) return mechOrder[a] < mechOrder[b] end)
 
 	modApi.mod_squads_by_id[squad.id] = squad
 

--- a/scripts/mod_loader/modapi/squad.lua
+++ b/scripts/mod_loader/modapi/squad.lua
@@ -17,6 +17,14 @@ local validMechClasses = {
 	"TechnoVek",
 }
 
+local CLASS_ORDER = {
+	Prime = 0,
+	Brute = 1,
+	Ranged = 2,
+	Science = 3,
+	TechnoVek = 4,
+}
+
 function modApi:addSquad(squad, name, desc, icon)
 	Assert.ModInitializingOrLoading()
 
@@ -43,6 +51,17 @@ function modApi:addSquad(squad, name, desc, icon)
 				ptable.Class,
 				string.format("Squad %q - pawn with id %q has an invalid Class", squad.id, mechType)
 		)
+
+		if i > 2 then
+			local ptable_prev = _G[squad[i-1]]
+			local pri = CLASS_ORDER[ptable.Class] or INT_MAX
+			local pri_prev = CLASS_ORDER[ptable_prev.Class] or INT_MAX
+
+			if pri < pri_prev then
+				-- swap entries
+				squad[i-1], squad[i] = squad[i], squad[i-1]
+			end
+		end
 	end
 
 	modApi.mod_squads_by_id[squad.id] = squad


### PR DESCRIPTION
The game orders units in a specific way in the hangar. Sort modded squads in the same order.
This should fix the issue where some modded squads would not display their squad achievements in the hangar ui.