### PR TITLE
Globalize exclusiveElements in spawner_backend

### DIFF
--- a/scripts/mod_loader/hard-alter.lua
+++ b/scripts/mod_loader/hard-alter.lua
@@ -38,6 +38,7 @@ end
 
 globalizeLocalVariable("scripts/text.lua", "Global_Texts")
 globalizeLocalVariable("scripts/spawner_backend.lua", "WeakPawns")
+globalizeLocalVariable("scripts/spawner_backend.lua", "exclusiveElements")
 globalizeLocalVariable("scripts/game.lua", "GameObject")
 globalizeLocalVariable("scripts/text_population.lua", "PopEvent")
 globalizeLocalVariable("scripts/personalities/personalities.lua", "PilotPersonality")


### PR DESCRIPTION
### Handling of exclusive enemies have been changed in itb 1.2.78

With the new beta patch for ITB, `../scripts/spawner_backend.lua` has changed the way exclusive enemies are listed and handled; and in the process the table has been made local, where it previously was global.

This makes it difficult to update EasyEdit which relied on accessing this list.