### PR TITLE
Add ability to serialize Point

### DIFF
--- a/scripts/mod_loader/sdlext/serialize.lua
+++ b/scripts/mod_loader/sdlext/serialize.lua
@@ -169,6 +169,10 @@ writers = {
 			table.insert(buffer, "nil --[[thread]]\n");
 		end;
 	["userdata"] = function (buffer, item)
-			table.insert(buffer, "nil --[[userdata]]\n");
+			if type(item.GetString) == "function" then
+				table.insert(buffer, item:GetString());
+			else
+				table.insert(buffer, "nil --[[userdata]]\n");
+			end
 		end;
 }


### PR DESCRIPTION
**Note:** Merged `feature/itb-io` #164 into branch to account for its changes to the serializer.

Point variables are used a lot in ITB, this change allows Point variables to be serialized to file, so they can be deserialized when the file is read.