### PR TITLE
Change the busy check for isAllDeployed

### DIFF
--- a/scripts/mod_loader/modapi/deployment.lua
+++ b/scripts/mod_loader/modapi/deployment.lua
@@ -212,7 +212,7 @@ local function updateDeploymentListener(mission)
 			and mechs[0].state == STATE_DEPLOYED
 			and mechs[1].state == STATE_DEPLOYED
 			and mechs[2].state == STATE_DEPLOYED
-			and pwn0:IsBusy()
+			and (pwn0:IsBusy() or pwn1:IsBusy() or pwn2:IsBusy())
 
 		if isAllDeployed then
 			deployment.phase = PHASE_LANDING


### PR DESCRIPTION
Check all three pawns at once instead of just pawn 0, to fix the issue of Deployment Effects not firing unless pawn 0 has deployed.