### PR TITLE
Events for Board:AddEffect and Board:DamageSpace

### DIFF
--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -128,6 +128,9 @@ t.onPawnUndeployed = Event()
 t.onPawnLanding = Event()
 t.onPawnLanded = Event()
 
+t.onBoardAddEffect = Event()
+t.onBoardDamageSpace = Event()
+
 t.onShiftToggled = Event()
 t.onAltToggled = Event()
 t.onCtrlToggled = Event()

--- a/scripts/mod_loader/modapi/board.lua
+++ b/scripts/mod_loader/modapi/board.lua
@@ -198,7 +198,24 @@ local function initializeBoardClass(board)
 
 
 	-- Override existing Board class functions here
+	BoardClass.AddEffectVanilla = board.AddEffect
+	BoardClass.AddEffect = function(self, effect)
+		Assert.Equals("userdata", type(self), "Argument #0")
+		Assert.Equals("userdata", type(effect), "Argument #1")
+		
+		modApi.events.onBoardAddEffect:dispatch(effect)
+		self:AddEffectVanilla(effect)
+	end
+	
+	BoardClass.DamageSpaceVanilla = board.DamageSpace
+	BoardClass.DamageSpace = function(self, spaceDamage)
+		Assert.Equals("userdata", type(self), "Argument #0")
+		Assert.Equals("userdata", type(spaceDamage), "Argument #1")
 
+		modApi.events.onBoardDamageSpace:dispatch(spaceDamage)
+		self:DamageSpaceVanilla(spaceDamage)
+	end
+	
 
 	modApi.events.onBoardClassInitialized:dispatch(boardClass, board)
 	modApi.events.onBoardClassInitialized:unsubscribeAll()

--- a/scripts/mod_loader/modapi/board.lua
+++ b/scripts/mod_loader/modapi/board.lua
@@ -208,14 +208,19 @@ local function initializeBoardClass(board)
 	end
 	
 	BoardClass.DamageSpaceVanilla = board.DamageSpace
-	BoardClass.DamageSpace = function(self, spaceDamage)
+	BoardClass.DamageSpace = function(self, spaceDamage, damage)
 		Assert.Equals("userdata", type(self), "Argument #0")
 		Assert.Equals("userdata", type(spaceDamage), "Argument #1")
+		Assert.Equals({"nil", "number"}, type(damage), "Argument #2")
 
+		if damage then
+			local point = spaceDamage
+			spaceDamage = SpaceDamage(point, damage)
+		end
+		
 		modApi.events.onBoardDamageSpace:dispatch(spaceDamage)
 		self:DamageSpaceVanilla(spaceDamage)
-	end
-	
+	end	
 
 	modApi.events.onBoardClassInitialized:dispatch(boardClass, board)
 	modApi.events.onBoardClassInitialized:unsubscribeAll()

--- a/scripts/mod_loader/modapi/board.lua
+++ b/scripts/mod_loader/modapi/board.lua
@@ -203,7 +203,18 @@ local function initializeBoardClass(board)
 		Assert.Equals("userdata", type(self), "Argument #0")
 		Assert.Equals("userdata", type(effect), "Argument #1")
 		
-		modApi.events.onBoardAddEffect:dispatch(effect)
+		if GetUserdataType(effect) == "SpaceDamage" then
+			local damage = effect
+			effect = SkillEffect()
+			effect:AddDamage(damage)
+		end
+		
+		if GetUserdataType(effect) == "SkillEffect" then
+			modApi.events.onBoardAddEffect:dispatch(effect)
+		else
+			LOG("Board:AddEffect argument must be a SkillEffect or SpaceDamage object")
+		end
+		
 		self:AddEffectVanilla(effect)
 	end
 	
@@ -213,12 +224,17 @@ local function initializeBoardClass(board)
 		Assert.Equals("userdata", type(spaceDamage), "Argument #1")
 		Assert.Equals({"nil", "number"}, type(damage), "Argument #2")
 
-		if damage then
+		if damage and GetUserdataType(spaceDamage) == "Point" then
 			local point = spaceDamage
 			spaceDamage = SpaceDamage(point, damage)
 		end
 		
-		modApi.events.onBoardDamageSpace:dispatch(spaceDamage)
+		if GetUserdataType(spaceDamage) == "SpaceDamage" then
+			modApi.events.onBoardDamageSpace:dispatch(spaceDamage)
+		else
+			LOG("Board:DamageSpace argument must be a SpaceDamage object or Point/Int pair")
+		end
+		
 		self:DamageSpaceVanilla(spaceDamage)
 	end	
 


### PR DESCRIPTION
Adds events that fire when `Board:AddEffect()` and `Board:DamageSpace()` are used, so their arguments can be manipulated. Addresses part of #201.

Need to update the [event wiki](https://github.com/itb-community/ITB-ModLoader/wiki/events#modapievents):

Table of contents update:
* modApi.events
	* Events related to board:
		* [onBoardAddEffect](#onBoardAddEffect)
		* [onBoardDamageSpace](#onBoardDamageSpace)

Content update:
# Events related to board

## `onBoardAddEffect`

| Argument name | Type | Description |
|---------------|------|-------------|
| `effect` | userdata | SkillEffect or SpaceDamage |

Fired just before Board:AddEffect(effect) is called, allowing the SkillEffect object to be manipulated first. The vanilla function can be called either as `Board:AddEffect(SkillEffect)` or `Board:AddEffect(SpaceDamage)`, but the event always passes a SkillEffect object. In the case of a SpaceDamage argument, a SkillEffect is created and the SpaceDamage object is added with `SkillEffect:AddDamage(SpaceDamage)`.

Example:
```lua
local handler = function(effect)
	LOG("Board:AddEffect() was used")
end

modApi.events.onBoardAddEffect:subscribe(handler)
```

&nbsp;

## `onBoardDamageSpace`

| Argument name | Type | Description |
|---------------|------|-------------|
| `spaceDamage` | userdata | SpaceDamage or Point |
| `damage` | number| Damage amount (used if argument 1 is a Point) |

Fired just before Board:DamageSpace(spaceDamage) is called, allowing the SpaceDamage object to be manipulated first. The vanilla function can be called either as `Board:DamageSpace(SpaceDamage)` or `Board:DamageSpace(Point, Int)`, but the event always passes a SpaceDamage object. In the case of point and damage arguments, `spaceDamage.loc = Point` and `spaceDamage.iDamage = damage`.

Example:
```lua
local handler = function(spaceDamage)
	LOG("Board:DamageSpace() was used")
end

modApi.events.onBoardDamageSpace:subscribe(handler)
```

&nbsp;