### PR TITLE
Fix crash when savedata directory path contains non-ascii characters

### DIFF
--- a/scripts/mod_loader/modapi/sandbox.lua
+++ b/scripts/mod_loader/modapi/sandbox.lua
@@ -13,7 +13,7 @@ function modApi:loadIntoEnv(scriptPath, envTable)
 
 	setmetatable(envTable, { __index = _G })
 	assert(pcall(setfenv(
-		assert(loadfile(scriptPath)),
+		assert(loadstring(File(scriptPath):read_to_string())),
 		envTable
 	)))
 	setmetatable(envTable, nil)


### PR DESCRIPTION
Packaged mod loader for testing: [ITB-ModLoader-PR207.zip](https://github.com/itb-community/ITB-ModLoader/files/11240992/ITB-ModLoader-PR207.zip)
