### PR TITLE
Add functions to check userdata type

### DIFF
--- a/scripts/mod_loader/modapi/__scripts.lua
+++ b/scripts/mod_loader/modapi/__scripts.lua
@@ -1,4 +1,5 @@
 local scripts = {
+	"userdataType",
 	"vector",
 	"init",
 	"global",

--- a/scripts/mod_loader/modapi/userdataType.lua
+++ b/scripts/mod_loader/modapi/userdataType.lua
@@ -1,0 +1,69 @@
+
+local function isUserdataClass(userdata)
+	Assert.Equals("userdata", type(userdata), "Argument #1")
+
+	return getmetatable(userdata).__luabind_classrep == true
+end
+
+local function isUserdataInstance(userdata)
+	Assert.Equals("userdata", type(userdata), "Argument #1")
+
+	return getmetatable(userdata).__luabind_class == true
+end
+
+function GetUserdataType(userdata)
+	Assert.Equals("userdata", type(userdata), "Argument #1")
+
+	if userdata.GetUserdataType then
+		return userdata:GetUserdataType()
+	end
+
+	return "Unknown"
+end
+
+function Point:GetUserdataType()
+	if isUserdataClass(self) then
+		return "PointClass"
+	end
+
+	return "Point"
+end
+
+function PAWN_FACTORY:GetUserdataType()
+	return "PAWN_FACTORY"
+end
+
+function Board:GetUserdataType()
+	return "Board"
+end
+
+function BoardPawn:GetUserdataType()
+	return "Pawn"
+end
+
+function SkillEffect:GetUserdataType()
+	if isUserdataClass(self) then
+		return "SkillEffectClass"
+	end
+
+	return "SkillEffect"
+end
+
+function SpaceDamage:GetUserdataType()
+	if isUserdataClass(self) then
+		return "SpaceDamageClass"
+	end
+
+	return "SpaceDamage"
+end
+
+function GameMap:GetUserdataType()
+	if isUserdataClass(self) then
+		return "GameClass"
+	end
+
+	return "Game"
+end
+
+modApi.isUserdataClass = isUserdataClass
+modApi.isUserdataInstance = isUserdataInstance


### PR DESCRIPTION
Adds functions to several userdata objects, to make it possible to check what kind of userdata object they are.
The intended use is to always call the global `GetUserdataType` function, instead of calling the various userdata objects' GetUserdataType functions; since a userdata object is not guaranteed to have a GetUserdataType function defined.

This PR will allow #205 to distinguish between SpaceDamage and SkillEffect objects in order to dispatch the appropriate events.

This might not be an exhaustive list of userdata types, so feel free to add to the list.

# userdata

This page describes helper functions for `userdata` objects that have been added as part of modding API.

&nbsp;

- [GetUserdataType](#GetUserdataType)
- [modApi.isUserdataClass](#modApiisUserdataClass)
- [modApi.isUserdataInstance](#modApiisUserdataInstance)
- [Game:GetUserdataType](#gamegetuserdatatype)
- [Board:GetUserdataType](#boardgetuserdatatype)
- [Pawn:GetUserdataType](#pawngetuserdatatype)
- [PAWN_FACTORY:GetUserdataType](#pawnfactorygetuserdatatype)
- [Point:GetUserdataType](#pointgetuserdatatype)
- [SkillEffect:GetUserdataType](#skilleffectgetuserdatatype)
- [SpaceDamage:GetUserdataType](#spacedamagegetuserdatatype)

&nbsp;

## `GetUserdataType`
| Argument name | Type | Description |
|---------------|------|-------------|
| `userdata` | userdata | The userdata object we want to query |

returns a string of the userdata type of the specified userdata, or "Unknown", if the userdata does not have a `GetUserdataType` function.

&nbsp;

## `modApi.isUserdataClass`
| Argument name | Type | Description |
|---------------|------|-------------|
| `userdata` | userdata | The userdata object we want to query |

returns `true` if the userdata object is a class, otherwise, `false`.

&nbsp;

## `modApi.isUserdataInstance`
| Argument name | Type | Description |
|---------------|------|-------------|
| `userdata` | userdata | The userdata object we want to query |

returns `true` if the userdata object is an instance of a class, otherwise, `false`.

&nbsp;

## `Game:GetUserdataType`

returns `"Game"`

&nbsp;

## `Board:GetUserdataType`

returns `"Board"`

&nbsp;

## `Pawn:GetUserdataType`

returns `"Pawn"`

&nbsp;

## `PAWN_FACTORY:GetUserdataType`

returns `"PAWN_FACTORY"`

&nbsp;

## `Point:GetUserdataType`

returns `"Point"` if it is a class instance, or `"PointClass"` if it is the Point class itself.

&nbsp;

## `SkillEffect:GetUserdataType`

returns `"SkillEffect"` if it is a class instance, or `"SkillEffectClass"` if it is the SkillEffect class itself.

&nbsp;

## `SpaceDamage:GetUserdataType`

returns `"SpaceDamage"` if it is a class instance, or `"SpaceDamageClass"` if it is the SpaceDamage class itself.

&nbsp;
