### PR TITLE
Fix gameState updating slightly too late

### DIFF
--- a/scripts/mod_loader/modapi/gameState.lua
+++ b/scripts/mod_loader/modapi/gameState.lua
@@ -86,6 +86,12 @@ modApi.events.onIslandLeft:subscribe(function()
 	setGameState(GAME_STATE.MAP)
 end)
 
+modApi.events.onPreMissionAvailable:subscribe(function(mission)
+	if mission.ID == "Mission_Final" then
+		setGameState(GAME_STATE.MAP)
+	end
+end)
+
 modApi.events.onMissionChanged:subscribe(function(mission, oldMission)
 	if mission == Mission_Test then
 		setGameState(GAME_STATE.MISSION_TEST)


### PR DESCRIPTION
Fix gameState updating slightly too late when the final mission becomes available.

This then also fixes the current tileset being updated to "volcano" as soon as the final mission becomes available; as well as any code that relies on accurate current tileset.