### PR TITLE
fix RegionData error on missions.lua

### DIFF
--- a/scripts/mod_loader/altered/missions.lua
+++ b/scripts/mod_loader/altered/missions.lua
@@ -301,16 +301,18 @@ function Mission:GetSaveData()
 		return nil
 	end
 
-	local i = 0
-	repeat
-		local regionData = RegionData["region"..i]
-		i = i + 1
-
-		if regionData and GAME:GetMissionId(regionData.mission) == mission_id then
-			return regionData.player
-		end
-	until regionData == nil
-
+	if RegionData then
+		local i = 0
+		repeat
+			local regionData = RegionData["region"..i]
+			i = i + 1
+	
+			if regionData and GAME:GetMissionId(regionData.mission) == mission_id then
+				return regionData.player
+			end
+		until regionData == nil
+	end
+	
 	return nil
 end
 


### PR DESCRIPTION
fix this error:
./scripts/mod_loader/altered/missions.lua:307: attempt to index global 'RegionData' (a nil value)
by checking for RegionData existence