### PR TITLE
Add Debug Mode

### DIFF
--- a/scripts/mod_loader/bootstrap/assert.lua
+++ b/scripts/mod_loader/bootstrap/assert.lua
@@ -39,11 +39,15 @@ local function has_equal(expected, actual)
 end
 
 function Assert.Error(msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	error(msg..traceback())
 end
 
 function Assert.ShouldError(func, args, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 
 	local ok = xpcall(function() func(unpack(args)) end, function(err) end)
@@ -51,42 +55,56 @@ function Assert.ShouldError(func, args, msg)
 end
 
 function Assert.Equals(expected, actual, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	msg = msg .. string.format("Expected %s, but was '%s'%s", get_string(expected), tostring(actual), traceback())
 	assert(has_equal(expected, actual), msg)
 end
 
 function Assert.NotEquals(notExpected, actual, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	msg = msg .. string.format("Expected '%s' to not be equal to %s%s", tostring(actual), get_string(notExpected), traceback())
 	assert(not has_equal(notExpected, actual), msg)
 end
 
 function Assert.True(condition, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	msg = msg .. string.format("Expected 'true', but was '%s'%s", tostring(condition), traceback())
 	assert(condition == true, msg)
 end
 
 function Assert.False(condition, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	msg = msg .. string.format("Expected 'false', but was '%s'%s", tostring(condition), traceback())
 	assert(condition == false, msg)
 end
 
 function Assert.TypePoint(arg, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	msg = msg .. string.format("Expected Point, but was %s%s", tostring(type(arg)), traceback())
 	assert(type(arg) == "userdata" and type(arg.x) == "number" and type(arg.y) == "number", msg)
 end
 
 function Assert.Range(from, to, actual, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	msg = msg .. string.format("Expected 'number' in range [%s,%s], but was '%s'%s", from, to, tostring(actual), traceback())
 	assert(actual >= from and actual <= to, msg)
 end
 
 function Assert.BoardStateEquals(expected, actual, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 
 	for index, expectedState in ipairs(expected.tiles) do
@@ -101,6 +119,8 @@ function Assert.BoardStateEquals(expected, actual, msg)
 end
 
 function Assert.TableEquals(expected, actual, msg)
+	if not modApi.debugMode then return end
+
 	local differences = {}
 	for k, v in pairs(expected) do
 		if v ~= actual[k] then
@@ -120,23 +140,31 @@ function Assert.TableEquals(expected, actual, msg)
 end
 
 function Assert.ResourceDatIsOpen(msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	assert(modApi.resource ~= nil, msg .. "Resource.dat is closed. It can only be modified while mods are initializing" .. traceback())
 end
 
 function Assert.ModInitializingOrLoading(msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	msg = msg .."No mod currently initializing or loading".. traceback()
 	assert(modApi.currentMod ~= nil, msg)
 end
 
 function Assert.FileExists(filePath, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	assert(type(filePath) == 'string', msg .. string.format("Expected 'string', but was '%s'%s", type(filePath), traceback()))
 	assert(modApi:fileExists(filePath), msg .. string.format("File '%s' could not be found%s", filePath, traceback()))
 end
 
 function Assert.DirectoryExists(dirPath, msg)
+	if not modApi.debugMode then return end
+
 	msg = (msg and msg .. ": ") or ""
 	assert(type(dirPath) == 'string', msg .. string.format("Expected 'string', but was '%s'%s", type(dirPath), traceback()))
 	assert(modApi:directoryExists(dirPath), msg .. string.format("Directory '%s' could not be found%s", dirPath, traceback()))
@@ -147,11 +175,15 @@ local function getCurrentModResourcePath()
 end
 
 function Assert.FileRelativeToCurrentModExists(filePathRelativeToCurrentMod, msg)
+	if not modApi.debugMode then return end
+
 	Assert.ModInitializingOrLoading(msg)
 	Assert.FileExists(getCurrentModResourcePath() .. filePathRelativeToCurrentMod, msg)
 end
 
 function Assert.DirectoryRelativeToCurrentModExists(dirPathRelativeToCurrentMod, msg)
+	if not modApi.debugMode then return end
+
 	Assert.ModInitializingOrLoading(msg)
 	Assert.DirectoryExists(getCurrentModResourcePath() .. dirPathRelativeToCurrentMod, msg)
 end

--- a/scripts/mod_loader/localization/dictionary_English.lua
+++ b/scripts/mod_loader/localization/dictionary_English.lua
@@ -188,6 +188,9 @@ return {
 	["ModLoaderConfig_Text_ProfileFrame"] = "Show Profile Settings Change Popup",
 	["ModLoaderConfig_Tooltip_ProfileFrame"] = "Show a popup reminding to restart the game when switching profiles with Profile-Specific Configuration enabled.",
 
+	["ModLoaderConfig_Text_NewsFrame"] = "Show Mod Loader News Popup",
+	["ModLoaderConfig_Tooltip_NewsFrame"] = "Show a popup of mod loader news on startup. Will automatically turn on when updating the mod loader to a new version.",
+
 	["ScriptError_FrameTitle"] = "Script Error",
 	["ScriptError_FrameText_Mount"] = "Unable to mount mod at [%s]:\n%s",
 
@@ -196,6 +199,8 @@ return {
 
 	["PaletteRestartRequired_FrameTitle"] = "Restart Required",
 	["PaletteRestartRequired_FrameText"] = "Order of squad palettes has been changed. You must restart the game for the changes to take effect.",
+
+	["ModLoaderNews_FrameTitle"] = "News",
 
 	["OldVersion_FrameTitle"] = "Mod Loader Outdated",
 	["OldVersion_FrameText"] = "The following mods could not be loaded, because they require a newer version of the mod loader:\n\n%s\nYour installed version: %s",

--- a/scripts/mod_loader/localization/dictionary_English.lua
+++ b/scripts/mod_loader/localization/dictionary_English.lua
@@ -150,9 +150,8 @@ return {
 	                                      "You shouldn't enable this, unless you're a mod creator or mod loader maintainer.",
 
 	["ModLoaderConfig_Text_DebugMode"] = "Debug mode",
-	["ModLoaderConfig_Tooltip_DebugMode"] = "Enhances mod stability by enabling assertions, which are checks used during development to catch bugs. "..
-	                                        "This mode prioritizes thorough error detection and troubleshooting capabilities, "..
-	                                        "ideal during development and testing phases to ensure robust functionality and identify potential issues early on.",
+	["ModLoaderConfig_Tooltip_DebugMode"] = "Enables assertions for catching bugs, allowing code to deliberately halt a program early, when an assertion has failed.\n\n"..
+	                                        "Recommended when developing/testing/debugging a mod or crash.",
 
 	["ModLoaderConfig_Text_FloatyTooltips"] = "Attach Tooltips To Mouse Cursor",
 	["ModLoaderConfig_Tooltip_FloatyTooltips_On"] = "Tooltips follow the mouse cursor around.",

--- a/scripts/mod_loader/localization/dictionary_English.lua
+++ b/scripts/mod_loader/localization/dictionary_English.lua
@@ -149,6 +149,11 @@ return {
 	["ModLoaderConfig_Tooltip_DevMode"] = "Enable debug mod loader features. May disrupt normal gameplay.\n\n"..
 	                                      "You shouldn't enable this, unless you're a mod creator or mod loader maintainer.",
 
+	["ModLoaderConfig_Text_DebugMode"] = "Debug mode",
+	["ModLoaderConfig_Tooltip_DebugMode"] = "Enhances mod stability by enabling assertions, which are checks used during development to catch bugs. "..
+	                                        "This mode prioritizes thorough error detection and troubleshooting capabilities, "..
+	                                        "ideal during development and testing phases to ensure robust functionality and identify potential issues early on.",
+
 	["ModLoaderConfig_Text_FloatyTooltips"] = "Attach Tooltips To Mouse Cursor",
 	["ModLoaderConfig_Tooltip_FloatyTooltips_On"] = "Tooltips follow the mouse cursor around.",
 	["ModLoaderConfig_Tooltip_FloatyTooltips_Off"] = "Tooltips show to the side of the UI element that spawned them, similar to the game's own tooltips.",

--- a/scripts/mod_loader/modapi/config.lua
+++ b/scripts/mod_loader/modapi/config.lua
@@ -21,6 +21,7 @@ function CurrentModLoaderConfig()
 	data.showPilotRestartReminder   = modApi.showPilotRestartReminder
 	data.showPaletteRestartReminder = modApi.showPaletteRestartReminder
 	data.showProfileSettingsFrame   = modApi.showProfileSettingsFrame
+	data.showNewsAboveVersion       = modApi.showNewsAboveVersion
 
 	return data
 end
@@ -78,7 +79,8 @@ function DefaultModLoaderConfig()
 		showRestartReminder = true,
 		showPilotRestartReminder   = true,
 		showPaletteRestartReminder = true,
-		showProfileSettingsFrame   = true
+		showProfileSettingsFrame   = true,
+		showNewsAboveVersion       = "0",
 	}
 end
 
@@ -165,6 +167,7 @@ function ApplyModLoaderConfig(config)
 	modApi.showPilotRestartReminder   = config.showPilotRestartReminder
 	modApi.showPaletteRestartReminder = config.showPaletteRestartReminder
 	modApi.showProfileSettingsFrame   = config.showProfileSettingsFrame
+	modApi.showNewsAboveVersion       = config.showNewsAboveVersion
 end
 
 modApi.events.onSettingsChanged:subscribe(function(old, neu)

--- a/scripts/mod_loader/modapi/config.lua
+++ b/scripts/mod_loader/modapi/config.lua
@@ -8,6 +8,7 @@ function CurrentModLoaderConfig()
 	data.warningLogs         = modApi.warningLogs
 	data.printCallerInfo     = mod_loader.logger:getPrintCallerInfo()
 	data.developmentMode     = modApi.developmentMode
+	data.debugMode           = modApi.debugMode
 
 	data.profileConfig       = modApi.profileConfig
 	data.floatyTooltips      = modApi.floatyTooltips
@@ -65,6 +66,7 @@ function DefaultModLoaderConfig()
 		clearLogFileOnStartup = true,
 
 		developmentMode     = false,
+		debugMode           = false,
 
 		floatyTooltips      = true,
 		profileConfig       = false,
@@ -150,6 +152,7 @@ function ApplyModLoaderConfig(config)
 	modApi.debugLogs              = config.debugLogs
 	modApi.warningLogs            = config.warningLogs
 	modApi.developmentMode        = config.developmentMode
+	modApi.debugMode              = config.debugMode
 
 	modApi.floatyTooltips         = config.floatyTooltips
 	modApi.profileConfig          = config.profileConfig

--- a/scripts/mod_loader/modui/__scripts.lua
+++ b/scripts/mod_loader/modui/__scripts.lua
@@ -13,6 +13,7 @@ local scripts = {
 	"popup_resource-error",
 	"popup_profile-config",
 	"popup_gamepad-warning",
+	"popup_news",
 
 	"modcontent",
 	"repair_icon_replace",

--- a/scripts/mod_loader/modui/modloader_configuration.lua
+++ b/scripts/mod_loader/modui/modloader_configuration.lua
@@ -30,6 +30,7 @@ local function createUi()
 	local cboxPilotRestartReminder = nil
 	local cboxPaletteRestartReminder = nil
 	local cboxProfileFrame = nil
+	local cboxNewsFrame = nil
 
 	local onExit = function(self)
 		local data = {
@@ -51,7 +52,8 @@ local function createUi()
 			showRestartReminder = cboxRestartReminder.checked,
 			showPilotRestartReminder   = cboxPilotRestartReminder.checked,
 			showPaletteRestartReminder = cboxPaletteRestartReminder.checked,
-			showProfileSettingsFrame   = cboxProfileFrame.checked
+			showProfileSettingsFrame   = cboxProfileFrame.checked,
+			showNewsAboveVersion       = cboxNewsFrame.checked and "0" or modApi.version,
 		}
 
 		ApplyModLoaderConfig(data)
@@ -81,6 +83,7 @@ local function createUi()
 		cboxPilotRestartReminder.checked   = config.showPilotRestartReminder
 		cboxPaletteRestartReminder.checked = config.showPaletteRestartReminder
 		cboxProfileFrame.checked           = config.showProfileSettingsFrame
+		cboxNewsFrame.checked              = modApi:isVersionBelow(config.showNewsAboveVersion, modApi.version)
 
 		local t = cboxFloatyTooltips.root.tooltip
 		modApi.floatyTooltips = config.floatyTooltips
@@ -375,6 +378,11 @@ local function createUi()
 		cboxProfileFrame = createCheckboxOption(
 			GetText("ModLoaderConfig_Text_ProfileFrame"),
 			GetText("ModLoaderConfig_Tooltip_ProfileFrame")
+		):addTo(popupsGroup.content)
+
+		cboxNewsFrame = createCheckboxOption(
+			GetText("ModLoaderConfig_Text_NewsFrame"),
+			GetText("ModLoaderConfig_Tooltip_NewsFrame")
 		):addTo(popupsGroup.content)
 
 		uiSetSettings(LoadModLoaderConfig())

--- a/scripts/mod_loader/modui/modloader_configuration.lua
+++ b/scripts/mod_loader/modui/modloader_configuration.lua
@@ -19,6 +19,7 @@ local function createUi()
 	local ddCaller = nil
 	local cboxClearLogs = nil
 	local cboxDevelopmentMode = nil
+	local cboxDebugMode = nil
 	local cboxFloatyTooltips = nil
 	local cboxProfileConfig = nil
 	local cboxErrorFrame = nil
@@ -39,6 +40,7 @@ local function createUi()
 			printCallerInfo       = ddCaller.value,
 			clearLogFileOnStartup = cboxClearLogs.checked,
 			developmentMode       = cboxDevelopmentMode.checked,
+			debugMode             = cboxDebugMode.checked,
 			floatyTooltips        = cboxFloatyTooltips.checked,
 			profileConfig         = cboxProfileConfig.checked,
 
@@ -67,6 +69,7 @@ local function createUi()
 		ddCaller.value                     = config.printCallerInfo
 		cboxClearLogs.checked              = config.clearLogFileOnStartup
 		cboxDevelopmentMode.checked        = config.developmentMode
+		cboxDebugMode.checked              = config.debugMode
 		cboxFloatyTooltips.checked         = config.floatyTooltips
 		cboxProfileConfig.checked          = config.profileConfig
 
@@ -282,6 +285,13 @@ local function createUi()
 		cboxDevelopmentMode = createCheckboxOption(
 			GetText("ModLoaderConfig_Text_DevMode"),
 			GetText("ModLoaderConfig_Tooltip_DevMode")
+		):addTo(layout)
+
+		-- ////////////////////////////////////////////////////////////////////////
+		-- Debug Mode
+		cboxDebugMode = createCheckboxOption(
+			GetText("ModLoaderConfig_Text_DebugMode"),
+			GetText("ModLoaderConfig_Tooltip_DebugMode")
 		):addTo(layout)
 
 		-- ////////////////////////////////////////////////////////////////////////

--- a/scripts/mod_loader/modui/popup_news.lua
+++ b/scripts/mod_loader/modui/popup_news.lua
@@ -4,6 +4,12 @@
 --]]
 
 local news = {
+"New Mode - Debug Mode\n"..
+"Enables assertions for catching bugs, allowing code to deliberately halt a program early, when an assertion has failed.\n\n"..
+"- Recommended when developing/testing/debugging a mod or crash.\n"..
+"- Defaults to off to optimize for playing finished mods.\n"..
+"- Previous mod loader versions used to run unoptimized.\n"..
+"- Change it via [Mod Content] > [Configure Mod Loader] > [Debug Mode]",
 }
 
 local function responseFn(btnIndex)

--- a/scripts/mod_loader/modui/popup_news.lua
+++ b/scripts/mod_loader/modui/popup_news.lua
@@ -1,0 +1,42 @@
+--[[
+	Adds a dialog option with particular important news about the current mod loader version.
+	These news should be removed and updated between mod loader releases.
+--]]
+
+local news = {
+}
+
+local function responseFn(btnIndex)
+	if btnIndex == 2 then
+		modApi.showNewsAboveVersion = modApi.version
+		SaveModLoaderConfig(CurrentModLoaderConfig())
+	end
+end
+
+local function showNewOptionDialog(text)
+	sdlext.showButtonDialog(
+		GetText("ModLoaderNews_FrameTitle"), text,
+		responseFn,
+		{ GetText("Button_Ok"), GetText("Button_DisablePopup") },
+		{ "", GetText("ButtonTooltip_DisablePopup") }
+	)
+end
+
+local newsShown = false
+modApi.events.onMainMenuEntered:subscribe(function(screen, wasHangar, wasGame)
+	if modApi:isVersionBelow(modApi.showNewsAboveVersion, modApi.version) then
+		if not newsShown then
+			newsShown = true
+
+			-- Schedule the error window to be shown instead of showing
+			-- it right away.
+			-- Prevents a bug where the console keeps scrolling upwards
+			-- due to the game not registering return key release event,
+			-- when using 'reload' command to reload scripts, and getting
+			-- a script error.
+			modApi:scheduleHook(50, function()
+				showNewOptionDialog(table.concat(news,"\n\n"))
+			end)
+		end
+	end
+end)


### PR DESCRIPTION
This essentially enables the opposite, by allowing us to turn off debug mode, and bypass asserts. Previously, we have always run with all asserts continuously on.

Adds an option to the mod loader's in-game configuration to change the flag `modApi.debugMode`, which if `true` will run `Assert` calls normally, and `false` bypass them.

Adds a news popup which can be used to show important news for the current mod loader release.
If disabled by the user, it will automatically be turned on when updating the mod loader to a new version.
Adds news about the Debug Mode via this popup.